### PR TITLE
Fix log writing and add header to log file

### DIFF
--- a/AirLog/__main__.py
+++ b/AirLog/__main__.py
@@ -1,7 +1,9 @@
 import data as csv
+import datetime
 
 __version__ = "0.2"
 callsign_endpoint = "http://hamcall.net/call?callsign="
+output_file_path = "../logs/" + str(datetime.datetime.today().strftime('%Y-%m-%d')) + ".csv"
 
 print(f"AirLog Version: {__version__}")
 
@@ -17,5 +19,5 @@ while 0 < len(questions):
 			data[question] = answer
 			questions.remove(question)
 
-headings = csv.toHeadings(data)
-csv.write(headings, data)
+headings = csv.toHeadings(data, output_file_path)
+csv.write(data, output_file_path)

--- a/AirLog/data.py
+++ b/AirLog/data.py
@@ -14,7 +14,6 @@ def write(heading, data):
 		line += f"{data[point]},"
 	line += str(datetime.datetime.now().time()).split(".")[0][:-3]+","
 	with open("../logs/" + str(datetime.datetime.today().strftime('%Y-%m-%d')) + ".csv", "w") as f:
-		file = f.read()
-		f.writelines(str(file) + line[:-1]+"\n")
+		f.writelines(line[:-1]+"\n")
 		f.close()
 		print("Log updated.")

--- a/AirLog/data.py
+++ b/AirLog/data.py
@@ -1,17 +1,19 @@
 import datetime
 
+
 def toHeadings(data):
 	output = []
 	for heading in data:
 		output.append(heading)
 	return output
 
+
 def write(heading, data):
 	line = ""
 	for point in data:
 		line += f"{data[point]},"
 	line += str(datetime.datetime.now().time()).split(".")[0][:-3]+","
-	with open("./logs/"+ str(datetime.datetime.today().strftime('%Y-%m-%d')) + ".csv", "w") as f:
+	with open("../logs/" + str(datetime.datetime.today().strftime('%Y-%m-%d')) + ".csv", "w") as f:
 		file = f.read()
 		f.writelines(str(file) + line[:-1]+"\n")
 		f.close()

--- a/AirLog/data.py
+++ b/AirLog/data.py
@@ -1,19 +1,31 @@
+import csv
 import datetime
+from os import path
 
 
-def toHeadings(data):
+def toHeadings(data, output_file_path):
 	output = []
-	for heading in data:
-		output.append(heading)
-	return output
+	row_count = 0
+	for heading_names, values in data.items():
+		output.append(heading_names)
+
+	# Check if logfile exists
+	if path.exists(output_file_path):
+		with open(output_file_path, "r") as f:
+			row_count = sum(1 for line in f)
+
+	if row_count == 0 or not path.exists(output_file_path):
+		with open(output_file_path, "w") as f:
+			writer = csv.writer(f)
+			writer.writerow(output)
 
 
-def write(heading, data):
+def write(data, output_file_path):
 	line = ""
 	for point in data:
 		line += f"{data[point]},"
 	line += str(datetime.datetime.now().time()).split(".")[0][:-3]+","
-	with open("../logs/" + str(datetime.datetime.today().strftime('%Y-%m-%d')) + ".csv", "w") as f:
+	with open(output_file_path, "a") as f:
 		f.writelines(line[:-1]+"\n")
 		f.close()
 		print("Log updated.")


### PR DESCRIPTION
Added code to `toHeadings()` to create the header row if it doesn't yet exist. Removed seemingly unused call to `f.read()` from `write()`.